### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/gradlew-publish-and-deploy.yml
+++ b/.github/workflows/gradlew-publish-and-deploy.yml
@@ -17,7 +17,7 @@ jobs:
       run: ./gradlew bootJar
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: romanew/realitica:latest
         username: ${{ secrets.DOCKER_PUBLISH_REGISTRY_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore